### PR TITLE
Fix: Add psutil dependency to fix CI test failures (#51)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ pytest==7.4.3
 pytest-asyncio==0.21.1
 httpx==0.26.0
 pytest-cov==4.1.0
+psutil==5.9.8
 
 # Image Processing & Forensics
 Pillow==10.2.0


### PR DESCRIPTION
## Changes
- Added `psutil==5.9.8` to `backend/requirements.txt`

## Problem Solved
Fixes #51

CI was failing with:
```
ModuleNotFoundError: No module named 'psutil'
  File "backend/tests/test_performance.py", line 6, in <module>
    import psutil
```

## Root Cause
- `test_performance.py` uses `psutil` to monitor memory usage during tests
- `psutil` was never added to requirements.txt
- Worked locally if psutil was globally installed, but failed in CI

## Solution
- Added `psutil==5.9.8` to Testing section of requirements.txt
- Placed after `pytest-cov==4.1.0` for logical grouping

## Testing
- [x] Local test: `pytest backend/tests/test_performance.py -v` ✅ PASS
- [x] All fast tests: `pytest backend/tests/ -v -m "not slow"` ✅ 105 passed, 2 skipped
- [x] CI will verify on push ⏳

## Impact
- **No breaking changes**
- **No API changes**
- **No functionality changes**
- Only adds missing dependency for existing test file

## Checklist
- [x] Requirements.txt updated
- [x] No conflicts with main
- [x] Tests pass locally
- [x] Commit message references issue #51
```

**Reviewers:** (Leave blank or assign yourself)

**Labels:** `bug`, `ci`, `testing`

**Click "Create pull request"**

---

# STEP 10: Wait for CI to Pass

GitHub Actions will automatically run. Wait ~2-3 minutes for the CI checks.

**Expected CI result:**
```
✅ Run Tests
   116 tests collected
   - 107 selected (fast tests)
   - 105 passed
   - 2 skipped
   - 9 deselected (slow ML tests)

✅ All checks have passed