### PR TITLE
Frontend evidence_id + Security dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ COPY . .
 # Install lightweight packages first, then heavy ones
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \
-    fastapi==0.109.0 \
+    fastapi==0.115.0 \
     "uvicorn[standard]==0.27.0" \
     pydantic==2.5.3 \
     pydantic-settings==2.1.0 \
     python-dotenv==1.0.0 \
     python-magic==0.4.27 \
-    python-multipart==0.0.6 \
-    Pillow==10.2.0 \
+    python-multipart==0.0.18 \
+    Pillow==10.4.0 \
     imagehash==4.3.1 \
     numpy==1.26.3 \
     scipy==1.11.4 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Core Framework
-fastapi==0.109.0
+fastapi==0.115.0
 uvicorn[standard]==0.27.0
 
 # Configuration Management
@@ -9,7 +9,7 @@ python-dotenv==1.0.0
 
 # File Processing
 python-magic==0.4.27
-python-multipart==0.0.6
+python-multipart==0.0.18
 
 # Testing
 pytest==7.4.3
@@ -19,7 +19,7 @@ pytest-cov==4.1.0
 psutil==5.9.8
 
 # Image Processing & Forensics
-Pillow==10.2.0
+Pillow==10.4.0
 imagehash==4.3.1
 
 # AI Detection & Analysis
@@ -34,7 +34,7 @@ PyWavelets==1.4.1
 scikit-image==0.22.0
 
 # Cryptography
-cryptography==41.0.7
+cryptography==43.0.1
 
 # Deep Learning Detection
 torch==2.1.0
@@ -51,4 +51,4 @@ regex==2023.12.25
 clip @ git+https://github.com/openai/CLIP.git
 
 # Dataset utilities
-tqdm==4.66.1
+tqdm==4.66.3


### PR DESCRIPTION
- frontend: show evidence_id on every analysis result
- requirements: cryptography 41→43.0.1 (CVE-2023-50782 etc)
- requirements: fastapi 0.109→0.115.0 (PYSEC-2024-38)
- requirements: python-multipart 0.0.6→0.0.18 (CVE-2024-53981)
- requirements: Pillow 10.2→10.4.0 (CVE-2024-28219)
- requirements: tqdm 4.66.1→4.66.3 (CVE-2024-34062)
- requirements: starlette updated (CVE-2024-47874)