### PR TITLE
fix(phase-20): wire jpeg_ghost and noise_map into ensemble scoring

### DIFF
--- a/backend/services/advanced_ensemble_detector.py
+++ b/backend/services/advanced_ensemble_detector.py
@@ -30,6 +30,8 @@ from backend.services.prnu_detector import detect_prnu
 from backend.services.ela_detector import detect_ela
 from backend.services.metadata_forensics import analyze_metadata
 from backend.services.dct_frequency_detector import detect_dct_artifacts
+from backend.services.jpeg_ghost_detector import detect_jpeg_ghost
+from backend.services.noise_map_detector import detect_noise_map
 
 logger = setup_logger(__name__)
 
@@ -60,7 +62,7 @@ class AdvancedEnsembleDetector(StatisticalDetector):
         Run complete advanced detection with all methods.
 
         Returns:
-            Complete report with 26 detection signals
+            Complete report with 28 detection signals
         """
         logger.info(f"Starting advanced ensemble detection for {self.filename}")
 
@@ -74,26 +76,34 @@ class AdvancedEnsembleDetector(StatisticalDetector):
         prnu_result     = detect_prnu(self.image_bytes, self.filename)
         ela_result      = detect_ela(self.image_bytes, self.filename)
         metadata_result = analyze_metadata(self.image_bytes, self.filename)
-        dct_result      = detect_dct_artifacts(self.image_bytes, self.filename)
+        dct_result        = detect_dct_artifacts(self.image_bytes, self.filename)
+        jpeg_ghost_result = detect_jpeg_ghost(self.image_bytes, self.filename)
+        noise_map_result  = detect_noise_map(self.image_bytes, self.filename)
 
-        # Combine all signals (26 total)
+        # Combine all 28 signals
         all_signals = base_report["all_signals"] + [
             dire_result, clip_result, own_result, prnu_result,
             ela_result, metadata_result, dct_result,
+            jpeg_ghost_result, noise_map_result,
         ]
 
         # Weighted fallback score (used when XGBoost model is absent)
         dire_confidence = dire_result.get("confidence", 0.0)
 
         if dire_confidence > 0.0:
+            # DIRE-available branch — weights sum to exactly 1.0
+            # stat=0.29 DIRE=0.22 CLIP=0.17 PRNU=0.08 ELA=0.07
+            # meta=0.06 DCT=0.05  jpeg=0.04 noise=0.02
             weighted_score = (
-                0.31 * base_report["ai_probability"] +
-                0.24 * dire_result["score"] +
-                0.18 * clip_result["score"] +
-                0.09 * prnu_result["score"] +
+                0.29 * base_report["ai_probability"] +
+                0.22 * dire_result["score"] +
+                0.17 * clip_result["score"] +
+                0.08 * prnu_result["score"] +
                 0.07 * ela_result["score"] +
                 0.06 * metadata_result["score"] +
-                0.05 * dct_result["score"]
+                0.05 * dct_result["score"] +
+                0.04 * jpeg_ghost_result["score"] +
+                0.02 * noise_map_result["score"]
             )
         else:
             logger.info("DIRE unavailable — using statistical+CLIP+OwnEmbedding+PRNU+ELA+metadata+DCT")
@@ -104,23 +114,27 @@ class AdvancedEnsembleDetector(StatisticalDetector):
                 )
             # Normalise weights to always sum to exactly 1.0
             _w = dict(
-                stat  = 0.40,
-                own   = own_weight,
-                clip  = 0.20,
-                prnu  = 0.10,
-                ela   = 0.08,
-                meta  = 0.06,
-                dct   = 0.04,
+                stat       = 0.40,
+                own        = own_weight,
+                clip       = 0.20,
+                prnu       = 0.10,
+                ela        = 0.08,
+                meta       = 0.06,
+                dct        = 0.04,
+                jpeg_ghost = 0.04,
+                noise_map  = 0.02,
             )
             _total = sum(_w.values())
             weighted_score = (
-                (_w["stat"]  / _total) * base_report["ai_probability"] +
-                (_w["own"]   / _total) * own_result["score"] +
-                (_w["clip"]  / _total) * clip_result["score"] +
-                (_w["prnu"]  / _total) * prnu_result["score"] +
-                (_w["ela"]   / _total) * ela_result["score"] +
-                (_w["meta"]  / _total) * metadata_result["score"] +
-                (_w["dct"]   / _total) * dct_result["score"]
+                (_w["stat"]       / _total) * base_report["ai_probability"] +
+                (_w["own"]        / _total) * own_result["score"] +
+                (_w["clip"]       / _total) * clip_result["score"] +
+                (_w["prnu"]       / _total) * prnu_result["score"] +
+                (_w["ela"]        / _total) * ela_result["score"] +
+                (_w["meta"]       / _total) * metadata_result["score"] +
+                (_w["dct"]        / _total) * dct_result["score"] +
+                (_w["jpeg_ghost"] / _total) * jpeg_ghost_result["score"] +
+                (_w["noise_map"]  / _total) * noise_map_result["score"]
             )
 
         # Platt-style calibration (weighted-sum fallback only)
@@ -183,11 +197,16 @@ class AdvancedEnsembleDetector(StatisticalDetector):
             "top_reasons":             top_reasons,
             "summary": (
                 f"Analyzed using {len(all_signals)} independent signals including "
-                f"statistical analysis, diffusion reconstruction, and semantic embeddings. "
+                f"statistical analysis, diffusion reconstruction, semantic embeddings, "
+                f"JPEG ghost analysis, and noise map forensics. "
                 f"{suspicious_count} signals indicate AI generation."
             ),
-            "detection_version": "advanced-ensemble-v1.4",
-            "methods_used": ["statistical", "dire", "clip", "own_embedding", "prnu", "ela", "metadata", "dct"],
+            "detection_version": "advanced-ensemble-v1.5",
+            "methods_used": [
+                "statistical", "dire", "clip", "own_embedding",
+                "prnu", "ela", "metadata", "dct",
+                "jpeg_ghost", "noise_map",
+            ],
         }
 
         logger.info(

--- a/backend/tests/test_advanced_ai_detector.py
+++ b/backend/tests/test_advanced_ai_detector.py
@@ -67,4 +67,4 @@ def test_forensics_integration(sample_image_bytes):
     assert "ai_detection" in report
     assert "all_signals" in report["ai_detection"]
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["summary"]["total_detection_signals"] == 26
+    assert report["summary"]["total_detection_signals"] == 28

--- a/backend/tests/test_advanced_ensemble.py
+++ b/backend/tests/test_advanced_ensemble.py
@@ -36,7 +36,7 @@ def test_advanced_ensemble_complete_detection(sample_image_bytes):
     assert "prnu" in report["methods_used"]
     
     # Check version
-    assert report["detection_version"] == "advanced-ensemble-v1.4"
+    assert report["detection_version"] == "advanced-ensemble-v1.5"
     
     # Cleanup
     detector.cleanup()
@@ -53,4 +53,4 @@ def test_advanced_ensemble_forensics_integration(sample_image_bytes):
     assert report["ai_detection"]["total_signals"] == 28
     assert "analyzer_version" in report["metadata"]
     assert "methods_used" in report["ai_detection"]
-    assert len(report["ai_detection"]["methods_used"]) == 8
+    assert len(report["ai_detection"]["methods_used"]) == 10

--- a/backend/tests/test_advanced_ensemble.py
+++ b/backend/tests/test_advanced_ensemble.py
@@ -26,8 +26,8 @@ def test_advanced_ensemble_complete_detection(sample_image_bytes):
     assert "methods_used" in report
     
     # Should have 21 signals (19 statistical + DIRE + CLIP)
-    assert report["total_signals"] == 26
-    assert len(report["all_signals"]) == 26
+    assert report["total_signals"] == 28
+    assert len(report["all_signals"]) == 28
     
     # Check methods used
     assert "statistical" in report["methods_used"]
@@ -50,7 +50,7 @@ def test_advanced_ensemble_forensics_integration(sample_image_bytes):
     report = forensics.generate_forensic_report()
     
     # Check advanced detection was used
-    assert report["ai_detection"]["total_signals"] == 26
+    assert report["ai_detection"]["total_signals"] == 28
     assert "analyzer_version" in report["metadata"]
     assert "methods_used" in report["ai_detection"]
     assert len(report["ai_detection"]["methods_used"]) == 8

--- a/backend/tests/test_covariance_detector.py
+++ b/backend/tests/test_covariance_detector.py
@@ -62,7 +62,7 @@ def test_covariance_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["ai_detection"]["total_signals"] == 26
+    assert report["ai_detection"]["total_signals"] == 28
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]
 

--- a/backend/tests/test_determinism.py
+++ b/backend/tests/test_determinism.py
@@ -20,8 +20,8 @@ def test_detection_is_deterministic(sample_image_bytes):
     assert report1["summary"]["ai_classification"] == report2["summary"]["ai_classification"]
     
     # Signal counts should be identical
-    assert report1["summary"]["total_detection_signals"] == 26
-    assert report2["summary"]["total_detection_signals"] == 26
+    assert report1["summary"]["total_detection_signals"] == 28
+    assert report2["summary"]["total_detection_signals"] == 28
 
 
 def test_hash_generation_is_consistent(sample_image_bytes):
@@ -61,8 +61,8 @@ def test_forensic_report_stability(sample_image_bytes):
     assert report1["hashes"]["sha256"] == report2["hashes"]["sha256"]
     
     # Signal counts should be identical
-    assert report1["summary"]["total_detection_signals"] == 26
-    assert report2["summary"]["total_detection_signals"] == 26
+    assert report1["summary"]["total_detection_signals"] == 28
+    assert report2["summary"]["total_detection_signals"] == 28
     assert report1["summary"]["total_detection_signals"] == report2["summary"]["total_detection_signals"]
     
     # AI probability: allow 20% variance for CLIP randomness
@@ -114,8 +114,8 @@ def test_signal_ordering_is_stable(sample_image_bytes):
     assert "ai_detection" in report2
     
     # Both should have 21 signals total
-    assert report1["ai_detection"]["total_signals"] == 26
-    assert report2["ai_detection"]["total_signals"] == 26
+    assert report1["ai_detection"]["total_signals"] == 28
+    assert report2["ai_detection"]["total_signals"] == 28
     
     # Classification keys should be consistent
     assert report1["ai_detection"]["classification"] == report2["ai_detection"]["classification"]

--- a/backend/tests/test_invariants.py
+++ b/backend/tests/test_invariants.py
@@ -70,7 +70,7 @@ def test_noise_image_signal_count():
     det = AdvancedEnsembleDetector(_make_noise_image(), "noise.jpg")
     r   = det.detect()
     det.cleanup()
-    assert r["total_signals"] == 26
+    assert r["total_signals"] == 28
     for sig in r["all_signals"]:
         assert 0.0 <= sig["score"] <= 1.0
         assert 0.0 <= sig["confidence"] <= 1.0
@@ -230,7 +230,7 @@ def test_forensic_report_complete_schema():
     missing = required - set(report.keys())
     assert not missing, f"Report missing keys: {missing}"
     assert 0.0 <= report["summary"]["ai_probability"] <= 1.0
-    assert report["summary"]["total_detection_signals"] == 26
+    assert report["summary"]["total_detection_signals"] == 28
     assert "platform_origin" in report["summary"]
     assert "c2pa_status" in report["summary"]
     assert "c2pa_status" in report["summary"]

--- a/backend/tests/test_statistical_detector.py
+++ b/backend/tests/test_statistical_detector.py
@@ -61,7 +61,7 @@ def test_statistical_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 25 signals: 19 statistical + DIRE + CLIP + PRNU + ELA + Metadata + DCT
-    assert report["ai_detection"]["total_signals"] == 26
+    assert report["ai_detection"]["total_signals"] == 28
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]
 

--- a/backend/tests/test_ultra_advanced_detector.py
+++ b/backend/tests/test_ultra_advanced_detector.py
@@ -60,6 +60,6 @@ def test_ultra_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["ai_detection"]["total_signals"] == 26
+    assert report["ai_detection"]["total_signals"] == 28
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]


### PR DESCRIPTION
Signals 27 and 28 existed in the SSE stream and as detector files but were never wired into advanced_ensemble_detector.py, meaning:
- all_signals only had 26 entries (not 28)
- ensemble score ignored both new signals entirely
- test_weights_sum_to_one failed (expected 9 weights summing to 1.0)

Changes:
- Import detect_jpeg_ghost and detect_noise_map at module level
- Call both detectors inside detect() alongside existing signals
- Add both results to all_signals list (now 28 total)
- DIRE branch: redistribute weights to include jpeg=0.04, noise=0.02 (stat 0.31->0.29, DIRE 0.24->0.22, CLIP 0.18->0.17, PRNU 0.09->0.08)
- Fallback branch: add jpeg_ghost=0.04, noise_map=0.02 to _w dict (auto-normalised via _total division, still sums to 1.0)
- detection_version: v1.4 -> v1.5
- methods_used list updated with jpeg_ghost and noise_map