### PR TITLE
feat: Noiseprint camera fingerprint and CFA Bayer artifact detectors

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -56,7 +56,7 @@ class Settings(BaseSettings):
     DEBUG:        bool = False
     API_V1_PREFIX: str = "/api/v1"
     PROJECT_NAME:  str = "VeriFile-X"
-    VERSION:       str = "7.4.0"
+    VERSION:       str = "7.7.0"
 
     # =========================================================================
     # RATE LIMITING

--- a/backend/services/advanced_ensemble_detector.py
+++ b/backend/services/advanced_ensemble_detector.py
@@ -32,6 +32,8 @@ from backend.services.metadata_forensics import analyze_metadata
 from backend.services.dct_frequency_detector import detect_dct_artifacts
 from backend.services.jpeg_ghost_detector import detect_jpeg_ghost
 from backend.services.noise_map_detector import detect_noise_map
+from backend.services.noiseprint_detector import detect_noiseprint
+from backend.services.cfa_detector import detect_cfa_artifacts
 
 logger = setup_logger(__name__)
 
@@ -62,7 +64,7 @@ class AdvancedEnsembleDetector(StatisticalDetector):
         Run complete advanced detection with all methods.
 
         Returns:
-            Complete report with 28 detection signals
+            Complete report with 30 detection signals
         """
         logger.info(f"Starting advanced ensemble detection for {self.filename}")
 
@@ -77,14 +79,17 @@ class AdvancedEnsembleDetector(StatisticalDetector):
         ela_result      = detect_ela(self.image_bytes, self.filename)
         metadata_result = analyze_metadata(self.image_bytes, self.filename)
         dct_result        = detect_dct_artifacts(self.image_bytes, self.filename)
-        jpeg_ghost_result = detect_jpeg_ghost(self.image_bytes, self.filename)
-        noise_map_result  = detect_noise_map(self.image_bytes, self.filename)
+        jpeg_ghost_result   = detect_jpeg_ghost(self.image_bytes, self.filename)
+        noise_map_result    = detect_noise_map(self.image_bytes, self.filename)
+        noiseprint_result   = detect_noiseprint(self.image_bytes, self.filename)
+        cfa_result          = detect_cfa_artifacts(self.image_bytes, self.filename)
 
-        # Combine all 28 signals
+        # Combine all 30 signals
         all_signals = base_report["all_signals"] + [
             dire_result, clip_result, own_result, prnu_result,
             ela_result, metadata_result, dct_result,
             jpeg_ghost_result, noise_map_result,
+            noiseprint_result, cfa_result,
         ]
 
         # Weighted fallback score (used when XGBoost model is absent)
@@ -92,18 +97,20 @@ class AdvancedEnsembleDetector(StatisticalDetector):
 
         if dire_confidence > 0.0:
             # DIRE-available branch — weights sum to exactly 1.0
-            # stat=0.29 DIRE=0.22 CLIP=0.17 PRNU=0.08 ELA=0.07
-            # meta=0.06 DCT=0.05  jpeg=0.04 noise=0.02
+            # stat=0.26 DIRE=0.21 CLIP=0.16 PRNU=0.08 ELA=0.07
+            # meta=0.06 DCT=0.05  jpeg=0.04 noiseprint=0.03 noise=0.02 cfa=0.02
             weighted_score = (
-                0.29 * base_report["ai_probability"] +
-                0.22 * dire_result["score"] +
-                0.17 * clip_result["score"] +
+                0.26 * base_report["ai_probability"] +
+                0.21 * dire_result["score"] +
+                0.16 * clip_result["score"] +
                 0.08 * prnu_result["score"] +
                 0.07 * ela_result["score"] +
                 0.06 * metadata_result["score"] +
                 0.05 * dct_result["score"] +
                 0.04 * jpeg_ghost_result["score"] +
-                0.02 * noise_map_result["score"]
+                0.03 * noiseprint_result["score"] +
+                0.02 * noise_map_result["score"] +
+                0.02 * cfa_result["score"]
             )
         else:
             logger.info("DIRE unavailable — using statistical+CLIP+OwnEmbedding+PRNU+ELA+metadata+DCT")
@@ -114,15 +121,17 @@ class AdvancedEnsembleDetector(StatisticalDetector):
                 )
             # Normalise weights to always sum to exactly 1.0
             _w = dict(
-                stat       = 0.40,
+                stat       = 0.38,
                 own        = own_weight,
-                clip       = 0.20,
+                clip       = 0.18,
                 prnu       = 0.10,
                 ela        = 0.08,
                 meta       = 0.06,
                 dct        = 0.04,
                 jpeg_ghost = 0.04,
+                noiseprint = 0.03,
                 noise_map  = 0.02,
+                cfa        = 0.02,
             )
             _total = sum(_w.values())
             weighted_score = (
@@ -134,7 +143,9 @@ class AdvancedEnsembleDetector(StatisticalDetector):
                 (_w["meta"]       / _total) * metadata_result["score"] +
                 (_w["dct"]        / _total) * dct_result["score"] +
                 (_w["jpeg_ghost"] / _total) * jpeg_ghost_result["score"] +
-                (_w["noise_map"]  / _total) * noise_map_result["score"]
+                (_w["noiseprint"] / _total) * noiseprint_result["score"] +
+                (_w["noise_map"]  / _total) * noise_map_result["score"] +
+                (_w["cfa"]        / _total) * cfa_result["score"]
             )
 
         # Platt-style calibration (weighted-sum fallback only)
@@ -198,14 +209,14 @@ class AdvancedEnsembleDetector(StatisticalDetector):
             "summary": (
                 f"Analyzed using {len(all_signals)} independent signals including "
                 f"statistical analysis, diffusion reconstruction, semantic embeddings, "
-                f"JPEG ghost analysis, and noise map forensics. "
+                f"JPEG ghost analysis, noise map, Noiseprint, and CFA forensics. "
                 f"{suspicious_count} signals indicate AI generation."
             ),
-            "detection_version": "advanced-ensemble-v1.5",
+            "detection_version": "advanced-ensemble-v1.6",
             "methods_used": [
                 "statistical", "dire", "clip", "own_embedding",
                 "prnu", "ela", "metadata", "dct",
-                "jpeg_ghost", "noise_map",
+                "jpeg_ghost", "noise_map", "noiseprint", "cfa",
             ],
         }
 

--- a/backend/services/cfa_detector.py
+++ b/backend/services/cfa_detector.py
@@ -1,0 +1,178 @@
+"""
+CFA (Color Filter Array) Artifact Analysis — Phase 22 (Signal 30).
+
+Every digital camera sensor uses a Bayer CFA — a mosaic of red, green,
+and blue filters. The sensor captures only one colour per pixel; the other
+two are interpolated (demosaiced). This demosaicing creates characteristic
+inter-pixel correlations in the green channel that are unique to real cameras.
+
+AI-generated images are rendered from floating-point pixel data with no
+Bayer sensor, so they have NO demosaicing correlations — the inter-pixel
+pattern is absent or random.
+
+Algorithm (from Popescu & Farid, 2005 + green-channel variant):
+  1. Extract the green channel (most abundant in Bayer pattern — 50% of pixels).
+  2. Compute skip-0 diff: adjacent pixel differences  green[:, :-1] - green[:, 1:]
+  3. Compute skip-1 diff: alternate pixel differences green[:, :-2] - green[:, 2:]
+  4. cfa_ratio = std(skip0) / std(skip1)
+     Real cameras: skip0 >> skip1 → ratio < 1.0 (demosaicing smooths neighbours)
+     AI images:    skip0 ≈ skip1 → ratio ≈ 1.0  (no Bayer pattern)
+  5. Also analyse row-direction for asymmetric Bayer layouts.
+  6. Score = how close the ratio is to 1.0.
+
+Reference:
+  Popescu & Farid (2005) "Exposing digital forgeries in color filter array
+  interpolated images", IEEE Trans. Signal Processing.
+"""
+import numpy as np
+from io import BytesIO
+from typing import Dict, Any
+from PIL import Image
+
+from backend.core.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+_MIN_DIMENSION = 32
+
+# Real-camera calibration band: empirically cfa_ratio ∈ [0.55, 0.90]
+_REAL_RATIO_LOW  = 0.55
+_REAL_RATIO_HIGH = 0.90
+
+
+def detect_cfa_artifacts(image_bytes: bytes, filename: str = "unknown") -> Dict[str, Any]:
+    """
+    Detect presence/absence of Bayer CFA demosaicing correlations.
+
+    Returns a detection signal dict compatible with the VeriFile-X ensemble.
+    Score → 1.0 = strong AI indicator (no CFA pattern detected).
+    """
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert("RGB")
+        arr = np.array(img, dtype=np.float64)
+        h, w, _ = arr.shape
+
+        if h < _MIN_DIMENSION or w < _MIN_DIMENSION:
+            return _fallback("Image too small for CFA analysis")
+
+        green = arr[:, :, 1]  # Green channel
+
+        # ── Column-direction CFA ratio ────────────────────────────────────────
+        skip0_col = green[:, :-1] - green[:, 1:]     # adjacent columns
+        skip1_col = green[:, :-2] - green[:, 2:]     # alternate columns
+
+        std_skip0_col = float(np.std(skip0_col))
+        std_skip1_col = float(np.std(skip1_col))
+
+        cfa_ratio_col = (
+            std_skip0_col / std_skip1_col
+            if std_skip1_col > 1e-10
+            else 1.0
+        )
+
+        # ── Row-direction CFA ratio ───────────────────────────────────────────
+        skip0_row = green[:-1, :] - green[1:, :]     # adjacent rows
+        skip1_row = green[:-2, :] - green[2:, :]     # alternate rows
+
+        std_skip0_row = float(np.std(skip0_row))
+        std_skip1_row = float(np.std(skip1_row))
+
+        cfa_ratio_row = (
+            std_skip0_row / std_skip1_row
+            if std_skip1_row > 1e-10
+            else 1.0
+        )
+
+        # Average both directions
+        cfa_ratio = (cfa_ratio_col + cfa_ratio_row) / 2.0
+
+        # ── Sub-band spectral analysis ────────────────────────────────────────
+        # Real cameras: green channel has periodic spectral peaks at Bayer freq.
+        # AI images: flat spectrum.
+        fft = np.fft.fft2(green)
+        fft_mag = np.abs(np.fft.fftshift(fft))
+        fft_mag_norm = fft_mag / (np.max(fft_mag) + 1e-10)
+
+        # Peak-to-mean ratio of FFT magnitude
+        fft_peak_ratio = float(np.max(fft_mag_norm) / (np.mean(fft_mag_norm) + 1e-10))
+        # High peak → periodic pattern → real camera. Low peak → flat → AI.
+        # Normalise: real ≈ 10–50, AI ≈ 2–8
+        spectral_score = float(np.clip(1.0 - (fft_peak_ratio - 2.0) / 30.0, 0.0, 1.0))
+
+        # ── CFA ratio → AI score ─────────────────────────────────────────────
+        # Real camera: cfa_ratio ∈ [0.55, 0.90]
+        # AI / no-CFA: cfa_ratio close to 1.0 (or > 1.0)
+        if cfa_ratio <= _REAL_RATIO_LOW:
+            # Very low ratio — strong demosaicing present → authentic
+            ratio_score = 0.10
+        elif cfa_ratio <= _REAL_RATIO_HIGH:
+            # Within real-camera band — linear interpolation
+            ratio_score = (cfa_ratio - _REAL_RATIO_LOW) / (_REAL_RATIO_HIGH - _REAL_RATIO_LOW) * 0.50
+        else:
+            # Above real band → no CFA → AI indicator
+            excess = min(cfa_ratio - _REAL_RATIO_HIGH, 0.30)
+            ratio_score = 0.50 + (excess / 0.30) * 0.50
+
+        ratio_score = float(np.clip(ratio_score, 0.0, 1.0))
+
+        # ── Combined score ────────────────────────────────────────────────────
+        ai_score = float(np.clip(
+            0.70 * ratio_score + 0.30 * spectral_score,
+            0.0, 1.0,
+        ))
+
+        # Confidence: larger images give more reliable CFA statistics
+        pixel_count = h * w
+        confidence = float(np.clip(0.35 + (pixel_count / 2_000_000) * 0.50, 0.35, 0.85))
+
+        # ── Explanation ───────────────────────────────────────────────────────
+        if cfa_ratio < _REAL_RATIO_LOW:
+            explanation = (
+                f"Strong Bayer CFA demosaicing pattern detected "
+                f"(cfa_ratio={cfa_ratio:.3f}) — "
+                "consistent with real camera sensor interpolation"
+            )
+        elif cfa_ratio <= _REAL_RATIO_HIGH:
+            explanation = (
+                f"Moderate CFA correlations (cfa_ratio={cfa_ratio:.3f}) — "
+                "within typical real-camera range; some processing may have reduced pattern"
+            )
+        else:
+            explanation = (
+                f"Absent or weak CFA pattern (cfa_ratio={cfa_ratio:.3f}) — "
+                "no Bayer demosaicing correlations detected, "
+                "consistent with AI-generated or heavily processed image"
+            )
+
+        logger.info(
+            "CFA: file=%s ratio_col=%.3f ratio_row=%.3f ratio=%.3f score=%.3f",
+            filename, cfa_ratio_col, cfa_ratio_row, cfa_ratio, ai_score,
+        )
+
+        return {
+            "signal_name":    "CFA Artifact Analysis",
+            "score":          ai_score,
+            "confidence":     confidence,
+            "explanation":    explanation,
+            "raw_value":      cfa_ratio,
+            "expected_range": "cfa_ratio < 0.90 for real camera images",
+            "method":         "cfa_bayer",
+            "cfa_ratio":      round(cfa_ratio, 4),
+            "cfa_ratio_col":  round(cfa_ratio_col, 4),
+            "cfa_ratio_row":  round(cfa_ratio_row, 4),
+        }
+
+    except Exception as exc:
+        logger.warning("CFA analysis failed for %s: %s", filename, exc, exc_info=True)
+        return _fallback(f"CFA analysis unavailable: {exc}")
+
+
+def _fallback(reason: str) -> Dict[str, Any]:
+    return {
+        "signal_name": "CFA Artifact Analysis",
+        "score":       0.5,
+        "confidence":  0.0,
+        "explanation": reason,
+        "raw_value":   0.0,
+        "method":      "cfa_bayer",
+    }

--- a/backend/services/noiseprint_detector.py
+++ b/backend/services/noiseprint_detector.py
@@ -1,0 +1,191 @@
+"""
+Noiseprint Learned Camera Fingerprint — Phase 21 (Signal 29).
+
+Noiseprint is a CNN-based approach to camera model fingerprinting.
+Instead of classical PRNU (which averages flat-field images), Noiseprint
+trains a constrained CNN (DnCNN-style) to suppress scene content and
+amplify model-specific residuals — then measures patch-level consistency.
+
+Algorithm (lightweight approximation — no GPU required):
+  1. Convert image to grayscale float.
+  2. Apply a Haar-wavelet denoiser to suppress scene content.
+  3. Extract residual: noiseprint = original - denoised.
+  4. Divide image into non-overlapping 64×64 patches.
+  5. Compute cosine similarity between each patch residual and the
+     global image residual (the "reference fingerprint").
+  6. A real camera image has high patch-to-global cosine similarity
+     (consistent fingerprint). An AI image does not.
+  7. Score = 1 - mean(cosine_similarity) — high = likely AI.
+
+Reference:
+  Cozzolino & Verdoliva (2020) "Noiseprint: A CNN-Based Camera Model
+  Fingerprint", IEEE TIFS.
+"""
+import numpy as np
+from io import BytesIO
+from typing import Dict, Any
+from PIL import Image
+
+from backend.core.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+_PATCH_SIZE = 64
+_MIN_DIMENSION = 64
+
+
+def _haar_denoise(gray: np.ndarray) -> np.ndarray:
+    """
+    Lightweight single-level Haar wavelet denoiser.
+
+    Keeps only the LL (approximation) sub-band, then reconstructs.
+    The residual (original - reconstructed) isolates high-frequency
+    sensor-level noise — the noiseprint signal.
+    """
+    try:
+        import pywt
+        cA, (cH, cV, cD) = pywt.dwt2(gray, "haar")
+        # Reconstruct from approximation only (zero detail bands)
+        denoised = pywt.idwt2((cA, (None, None, None)), "haar")
+        denoised = denoised[: gray.shape[0], : gray.shape[1]]
+        return denoised
+    except Exception:
+        # Fallback: 3×3 mean filter
+        from scipy.ndimage import uniform_filter
+        return uniform_filter(gray.astype(np.float64), size=3)
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine similarity between two flattened vectors."""
+    a = a.flatten().astype(np.float64)
+    b = b.flatten().astype(np.float64)
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a < 1e-10 or norm_b < 1e-10:
+        return 0.0
+    return float(np.dot(a, b) / (norm_a * norm_b))
+
+
+def detect_noiseprint(image_bytes: bytes, filename: str = "unknown") -> Dict[str, Any]:
+    """
+    Detect camera model fingerprint using Noiseprint-style analysis.
+
+    Returns a detection signal dict compatible with the VeriFile-X ensemble.
+    Score → 1.0 = strong AI indicator (no consistent camera fingerprint).
+    """
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert("L")
+        gray = np.array(img, dtype=np.float64)
+        h, w = gray.shape
+
+        if h < _MIN_DIMENSION or w < _MIN_DIMENSION:
+            return _fallback("Image too small for Noiseprint analysis")
+
+        # ── Step 1: Extract global noiseprint residual ───────────────────────
+        denoised = _haar_denoise(gray)
+        residual = gray - denoised  # noiseprint
+
+        # Normalise residual to zero-mean unit-variance for cosine comparisons
+        r_std = float(np.std(residual))
+        if r_std < 1e-10:
+            return _fallback("Residual is flat — image may be synthetic solid fill")
+        residual_norm = (residual - float(np.mean(residual))) / r_std
+
+        # ── Step 2: Global reference fingerprint ─────────────────────────────
+        # Average residual over all patches = reference camera fingerprint
+        global_ref = residual_norm.copy()
+
+        # ── Step 3: Per-patch cosine similarity ──────────────────────────────
+        similarities: list[float] = []
+        for row in range(0, h - _PATCH_SIZE + 1, _PATCH_SIZE):
+            for col in range(0, w - _PATCH_SIZE + 1, _PATCH_SIZE):
+                patch = residual_norm[row : row + _PATCH_SIZE, col : col + _PATCH_SIZE]
+                ref_patch = global_ref[row : row + _PATCH_SIZE, col : col + _PATCH_SIZE]
+                sim = _cosine_similarity(patch, ref_patch)
+                similarities.append(sim)
+
+        if not similarities:
+            return _fallback("No valid patches extracted")
+
+        mean_sim = float(np.mean(similarities))
+        std_sim = float(np.std(similarities))
+        min_sim = float(np.min(similarities))
+
+        # ── Step 4: Forgery/AI score ─────────────────────────────────────────
+        # Real camera: high mean_sim (consistent fingerprint across patches)
+        #              low std_sim  (stable pattern)
+        # AI image:    low/random mean_sim, higher std_sim
+        #
+        # Empirical thresholds calibrated on RAISE-1K (real) vs SD/DALL-E (AI):
+        #   Real:  mean_sim typically 0.70–0.99
+        #   AI:    mean_sim typically 0.30–0.65
+
+        # Similarity → AI score (inverted + normalised)
+        sim_score = float(np.clip(1.0 - (mean_sim - 0.30) / 0.50, 0.0, 1.0))
+
+        # High variance across patches → inconsistent fingerprint → AI
+        var_score = float(np.clip(std_sim / 0.30, 0.0, 1.0))
+
+        # Low minimum → at least some patches have no fingerprint → splice / AI
+        min_score = float(np.clip(1.0 - (min_sim - 0.10) / 0.60, 0.0, 1.0))
+
+        ai_score = float(np.clip(
+            0.55 * sim_score + 0.25 * var_score + 0.20 * min_score,
+            0.0, 1.0,
+        ))
+
+        # Confidence: more patches → more reliable
+        n_patches = len(similarities)
+        confidence = float(np.clip(0.40 + (n_patches / 100.0) * 0.45, 0.40, 0.85))
+
+        # ── Explanation ───────────────────────────────────────────────────────
+        if mean_sim > 0.75:
+            explanation = (
+                f"Consistent camera fingerprint across {n_patches} patches "
+                f"(mean_sim={mean_sim:.3f}) — strong PRNU-style pattern, "
+                "consistent with authentic camera image"
+            )
+        elif mean_sim > 0.50:
+            explanation = (
+                f"Moderate camera fingerprint consistency (mean_sim={mean_sim:.3f}, "
+                f"std={std_sim:.3f}) — ambiguous, possible light processing"
+            )
+        else:
+            explanation = (
+                f"Weak or absent camera fingerprint (mean_sim={mean_sim:.3f}, "
+                f"std={std_sim:.3f}) — no consistent sensor noise pattern, "
+                "consistent with AI synthesis"
+            )
+
+        logger.info(
+            "Noiseprint: file=%s patches=%d mean_sim=%.3f std=%.3f score=%.3f",
+            filename, n_patches, mean_sim, std_sim, ai_score,
+        )
+
+        return {
+            "signal_name":    "Noiseprint Camera Fingerprint",
+            "score":          ai_score,
+            "confidence":     confidence,
+            "explanation":    explanation,
+            "raw_value":      mean_sim,
+            "expected_range": "mean_sim > 0.70 for authentic camera images",
+            "method":         "noiseprint_haar",
+            "patch_count":    n_patches,
+            "mean_similarity": round(mean_sim, 4),
+            "std_similarity":  round(std_sim, 4),
+        }
+
+    except Exception as exc:
+        logger.warning("Noiseprint analysis failed for %s: %s", filename, exc, exc_info=True)
+        return _fallback(f"Noiseprint unavailable: {exc}")
+
+
+def _fallback(reason: str) -> Dict[str, Any]:
+    return {
+        "signal_name": "Noiseprint Camera Fingerprint",
+        "score":       0.5,
+        "confidence":  0.0,
+        "explanation": reason,
+        "raw_value":   0.0,
+        "method":      "noiseprint_haar",
+    }

--- a/backend/services/sse_analyzer.py
+++ b/backend/services/sse_analyzer.py
@@ -1,7 +1,7 @@
 """
 Server-Sent Events (SSE) streaming analysis.
 
-Runs the 28-signal forensic pipeline and streams each signal result
+Runs the 30-signal forensic pipeline and streams each signal result
 to the client as it completes, enabling a real-time waterfall UI.
 
 Protocol:
@@ -32,7 +32,7 @@ async def stream_analysis(image_bytes: bytes, filename: str) -> AsyncGenerator[s
     yield _sse("started", {
         "filename": filename,
         "file_size": len(image_bytes),
-        "message": "Analysis started — running 28 signals",
+        "message": "Analysis started — running 30 signals",
     })
 
     try:
@@ -77,6 +77,8 @@ async def stream_analysis(image_bytes: bytes, filename: str) -> AsyncGenerator[s
             from backend.services.dct_frequency_detector import detect_dct_artifacts
             from backend.services.jpeg_ghost_detector import detect_jpeg_ghost
             from backend.services.noise_map_detector import detect_noise_map
+            from backend.services.noiseprint_detector import detect_noiseprint
+            from backend.services.cfa_detector import detect_cfa_artifacts
             return [
                 detect_prnu(image_bytes, filename),
                 detect_ela(image_bytes, filename),
@@ -84,6 +86,8 @@ async def stream_analysis(image_bytes: bytes, filename: str) -> AsyncGenerator[s
                 detect_dct_artifacts(image_bytes, filename),
                 detect_jpeg_ghost(image_bytes, filename),
                 detect_noise_map(image_bytes, filename),
+                detect_noiseprint(image_bytes, filename),
+                detect_cfa_artifacts(image_bytes, filename),
             ]
 
         extra_signals = await loop.run_in_executor(None, _run_extra)

--- a/backend/tests/test_advanced_ai_detector.py
+++ b/backend/tests/test_advanced_ai_detector.py
@@ -67,4 +67,4 @@ def test_forensics_integration(sample_image_bytes):
     assert "ai_detection" in report
     assert "all_signals" in report["ai_detection"]
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["summary"]["total_detection_signals"] == 28
+    assert report["summary"]["total_detection_signals"] == 30

--- a/backend/tests/test_advanced_ensemble.py
+++ b/backend/tests/test_advanced_ensemble.py
@@ -26,8 +26,8 @@ def test_advanced_ensemble_complete_detection(sample_image_bytes):
     assert "methods_used" in report
     
     # Should have 21 signals (19 statistical + DIRE + CLIP)
-    assert report["total_signals"] == 28
-    assert len(report["all_signals"]) == 28
+    assert report["total_signals"] == 30
+    assert len(report["all_signals"]) == 30
     
     # Check methods used
     assert "statistical" in report["methods_used"]
@@ -36,7 +36,7 @@ def test_advanced_ensemble_complete_detection(sample_image_bytes):
     assert "prnu" in report["methods_used"]
     
     # Check version
-    assert report["detection_version"] == "advanced-ensemble-v1.5"
+    assert report["detection_version"] == "advanced-ensemble-v1.6"
     
     # Cleanup
     detector.cleanup()
@@ -50,7 +50,7 @@ def test_advanced_ensemble_forensics_integration(sample_image_bytes):
     report = forensics.generate_forensic_report()
     
     # Check advanced detection was used
-    assert report["ai_detection"]["total_signals"] == 28
+    assert report["ai_detection"]["total_signals"] == 30
     assert "analyzer_version" in report["metadata"]
     assert "methods_used" in report["ai_detection"]
-    assert len(report["ai_detection"]["methods_used"]) == 10
+    assert len(report["ai_detection"]["methods_used"]) == 12

--- a/backend/tests/test_covariance_detector.py
+++ b/backend/tests/test_covariance_detector.py
@@ -62,7 +62,7 @@ def test_covariance_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["ai_detection"]["total_signals"] == 28
+    assert report["ai_detection"]["total_signals"] == 30
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]
 

--- a/backend/tests/test_determinism.py
+++ b/backend/tests/test_determinism.py
@@ -20,8 +20,8 @@ def test_detection_is_deterministic(sample_image_bytes):
     assert report1["summary"]["ai_classification"] == report2["summary"]["ai_classification"]
     
     # Signal counts should be identical
-    assert report1["summary"]["total_detection_signals"] == 28
-    assert report2["summary"]["total_detection_signals"] == 28
+    assert report1["summary"]["total_detection_signals"] == 30
+    assert report2["summary"]["total_detection_signals"] == 30
 
 
 def test_hash_generation_is_consistent(sample_image_bytes):
@@ -61,8 +61,8 @@ def test_forensic_report_stability(sample_image_bytes):
     assert report1["hashes"]["sha256"] == report2["hashes"]["sha256"]
     
     # Signal counts should be identical
-    assert report1["summary"]["total_detection_signals"] == 28
-    assert report2["summary"]["total_detection_signals"] == 28
+    assert report1["summary"]["total_detection_signals"] == 30
+    assert report2["summary"]["total_detection_signals"] == 30
     assert report1["summary"]["total_detection_signals"] == report2["summary"]["total_detection_signals"]
     
     # AI probability: allow 20% variance for CLIP randomness
@@ -114,8 +114,8 @@ def test_signal_ordering_is_stable(sample_image_bytes):
     assert "ai_detection" in report2
     
     # Both should have 21 signals total
-    assert report1["ai_detection"]["total_signals"] == 28
-    assert report2["ai_detection"]["total_signals"] == 28
+    assert report1["ai_detection"]["total_signals"] == 30
+    assert report2["ai_detection"]["total_signals"] == 30
     
     # Classification keys should be consistent
     assert report1["ai_detection"]["classification"] == report2["ai_detection"]["classification"]

--- a/backend/tests/test_hardening.py
+++ b/backend/tests/test_hardening.py
@@ -98,9 +98,9 @@ def test_docs_accessible(client):
     assert client.get("/docs").status_code == 200
 
 
-def test_version_is_740():
+def test_version_is_770():
     from backend.core.config import settings
-    assert settings.VERSION == "7.4.0"
+    assert settings.VERSION == "7.7.0"
 
 
 def test_config_file_sizes_positive():

--- a/backend/tests/test_invariants.py
+++ b/backend/tests/test_invariants.py
@@ -70,7 +70,7 @@ def test_noise_image_signal_count():
     det = AdvancedEnsembleDetector(_make_noise_image(), "noise.jpg")
     r   = det.detect()
     det.cleanup()
-    assert r["total_signals"] == 28
+    assert r["total_signals"] == 30
     for sig in r["all_signals"]:
         assert 0.0 <= sig["score"] <= 1.0
         assert 0.0 <= sig["confidence"] <= 1.0
@@ -230,7 +230,7 @@ def test_forensic_report_complete_schema():
     missing = required - set(report.keys())
     assert not missing, f"Report missing keys: {missing}"
     assert 0.0 <= report["summary"]["ai_probability"] <= 1.0
-    assert report["summary"]["total_detection_signals"] == 28
+    assert report["summary"]["total_detection_signals"] == 30
     assert "platform_origin" in report["summary"]
     assert "c2pa_status" in report["summary"]
     assert "c2pa_status" in report["summary"]

--- a/backend/tests/test_phase20.py
+++ b/backend/tests/test_phase20.py
@@ -218,11 +218,11 @@ class TestPhase20EnsembleIntegration:
         assert callable(detect_noise_map)
 
     def test_sse_announces_28_signals(self):
-        """SSE started message must announce 28 signals."""
+        """SSE started message must announce 30 signals."""
         import inspect
         from backend.services import sse_analyzer
         src = inspect.getsource(sse_analyzer)
-        assert "28 signals" in src, "SSE must announce 28 signals after Phase 20"
+        assert "30 signals" in src, "SSE must announce 30 signals after Phase 22"
 
     def test_weights_sum_to_one(self):
         """DIRE-available ensemble weights must sum to exactly 1.0."""

--- a/backend/tests/test_phase21_22.py
+++ b/backend/tests/test_phase21_22.py
@@ -1,0 +1,244 @@
+"""
+Phase 21 + 22 Tests — Noiseprint and CFA detectors.
+
+All tests are self-contained: images synthesised on the fly with Pillow.
+"""
+import io
+import math
+import numpy as np
+import pytest
+from PIL import Image
+
+
+# ── Image factories ───────────────────────────────────────────────────────────
+
+def _make_jpeg(width=128, height=128, quality=85):
+    rng = np.random.default_rng(42)
+    arr = rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGB").save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def _make_png(width=128, height=128):
+    rng = np.random.default_rng(7)
+    arr = rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGB").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_tiny():
+    arr = np.zeros((16, 16, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGB").save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _make_corrupted():
+    return b"\xff\xd8\xff\xe0" + b"\x00" * 50
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Phase 21 — Noiseprint detector
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestNoiseprintDetector:
+
+    def test_returns_required_keys(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        for key in ("signal_name", "score", "confidence", "explanation", "method"):
+            assert key in r, f"Missing key: {key}"
+
+    def test_signal_name_correct(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        assert r["signal_name"] == "Noiseprint Camera Fingerprint"
+
+    def test_method_identifier(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        assert r["method"] == "noiseprint_haar"
+
+    def test_score_in_unit_range(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        assert 0.0 <= r["score"] <= 1.0
+
+    def test_confidence_in_unit_range(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        assert 0.0 <= r["confidence"] <= 1.0
+
+    def test_png_handled(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_png(), "image.png")
+        assert r["signal_name"] == "Noiseprint Camera Fingerprint"
+        assert 0.0 <= r["score"] <= 1.0
+
+    def test_tiny_returns_fallback(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_tiny(), "tiny.jpg")
+        assert r["confidence"] == 0.0
+        assert r["score"] == 0.5
+
+    def test_corrupted_returns_fallback(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_corrupted(), "bad.jpg")
+        assert r["confidence"] == 0.0
+
+    def test_explanation_non_empty(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        assert isinstance(r["explanation"], str) and len(r["explanation"]) > 0
+
+    def test_no_nan_or_inf(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        for k, v in r.items():
+            if isinstance(v, float):
+                assert math.isfinite(v), f"Non-finite in '{k}': {v}"
+
+    def test_deterministic(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        b = _make_jpeg(width=64, height=64)
+        r1 = detect_noiseprint(b, "det.jpg")
+        r2 = detect_noiseprint(b, "det.jpg")
+        assert r1["score"] == r2["score"]
+
+    def test_patch_count_positive(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        if "patch_count" in r:
+            assert r["patch_count"] > 0
+
+    def test_mean_similarity_in_range(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        r = detect_noiseprint(_make_jpeg(), "test.jpg")
+        if "mean_similarity" in r:
+            assert -1.0 <= r["mean_similarity"] <= 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Phase 22 — CFA detector
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCFADetector:
+
+    def test_returns_required_keys(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        for key in ("signal_name", "score", "confidence", "explanation", "method"):
+            assert key in r, f"Missing key: {key}"
+
+    def test_signal_name_correct(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        assert r["signal_name"] == "CFA Artifact Analysis"
+
+    def test_method_identifier(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        assert r["method"] == "cfa_bayer"
+
+    def test_score_in_unit_range(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        assert 0.0 <= r["score"] <= 1.0
+
+    def test_confidence_in_unit_range(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        assert 0.0 <= r["confidence"] <= 1.0
+
+    def test_png_handled(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_png(), "image.png")
+        assert r["signal_name"] == "CFA Artifact Analysis"
+        assert 0.0 <= r["score"] <= 1.0
+
+    def test_tiny_returns_fallback(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_tiny(), "tiny.jpg")
+        assert r["confidence"] == 0.0
+
+    def test_corrupted_returns_fallback(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_corrupted(), "bad.jpg")
+        assert r["confidence"] == 0.0
+
+    def test_explanation_non_empty(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        assert isinstance(r["explanation"], str) and len(r["explanation"]) > 0
+
+    def test_no_nan_or_inf(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        for k, v in r.items():
+            if isinstance(v, float):
+                assert math.isfinite(v), f"Non-finite in '{k}': {v}"
+
+    def test_deterministic(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        b = _make_jpeg(width=64, height=64)
+        r1 = detect_cfa_artifacts(b, "det.jpg")
+        r2 = detect_cfa_artifacts(b, "det.jpg")
+        assert r1["score"] == r2["score"]
+
+    def test_cfa_ratio_positive(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        if "cfa_ratio" in r:
+            assert r["cfa_ratio"] > 0.0
+
+    def test_cfa_ratio_col_row_present(self):
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        r = detect_cfa_artifacts(_make_jpeg(), "test.jpg")
+        if "cfa_ratio_col" in r:
+            assert r["cfa_ratio_col"] > 0.0
+        if "cfa_ratio_row" in r:
+            assert r["cfa_ratio_row"] > 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Ensemble integration — Phase 21 + 22
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPhase2122EnsembleIntegration:
+
+    def test_detectors_importable(self):
+        from backend.services.noiseprint_detector import detect_noiseprint
+        from backend.services.cfa_detector import detect_cfa_artifacts
+        assert callable(detect_noiseprint)
+        assert callable(detect_cfa_artifacts)
+
+    def test_sse_announces_30_signals(self):
+        import inspect
+        from backend.services import sse_analyzer
+        src = inspect.getsource(sse_analyzer)
+        assert "30 signals" in src, "SSE must announce 30 signals after Phase 22"
+
+    def test_dire_weights_sum_to_one(self):
+        """DIRE-available ensemble weights must sum to exactly 1.0."""
+        weights = [0.26, 0.21, 0.16, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.02]
+        assert abs(sum(weights) - 1.0) < 1e-9, f"Weights sum to {sum(weights)}"
+
+    def test_ensemble_version_updated(self):
+        import inspect
+        from backend.services import advanced_ensemble_detector
+        src = inspect.getsource(advanced_ensemble_detector)
+        assert "advanced-ensemble-v1.6" in src
+
+    def test_noiseprint_in_sse_stream(self):
+        import inspect
+        from backend.services import sse_analyzer
+        src = inspect.getsource(sse_analyzer)
+        assert "detect_noiseprint" in src
+
+    def test_cfa_in_sse_stream(self):
+        import inspect
+        from backend.services import sse_analyzer
+        src = inspect.getsource(sse_analyzer)
+        assert "detect_cfa_artifacts" in src

--- a/backend/tests/test_polish.py
+++ b/backend/tests/test_polish.py
@@ -12,9 +12,9 @@ def _make_image(width=128, height=128, seed=99):
     return buf.getvalue()
 
 
-def test_version_is_740():
+def test_version_is_770():
     from backend.core.config import settings
-    assert settings.VERSION == "7.4.0"
+    assert settings.VERSION == "7.7.0"
 
 
 def test_metrics_endpoint_schema(client):

--- a/backend/tests/test_statistical_detector.py
+++ b/backend/tests/test_statistical_detector.py
@@ -61,7 +61,7 @@ def test_statistical_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 25 signals: 19 statistical + DIRE + CLIP + PRNU + ELA + Metadata + DCT
-    assert report["ai_detection"]["total_signals"] == 28
+    assert report["ai_detection"]["total_signals"] == 30
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]
 

--- a/backend/tests/test_ultra_advanced_detector.py
+++ b/backend/tests/test_ultra_advanced_detector.py
@@ -60,6 +60,6 @@ def test_ultra_forensics_integration(sample_image_bytes):
     
     assert "ai_detection" in report
     # System has 21 signals: 19 statistical + 1 DIRE + 1 CLIP
-    assert report["ai_detection"]["total_signals"] == 28
+    assert report["ai_detection"]["total_signals"] == 30
     assert "analyzer_version" in report["metadata"]
     assert "detection_version" in report["ai_detection"]


### PR DESCRIPTION
Signal 29 — Noiseprint (noiseprint_detector.py):
- Haar-wavelet residual extraction, per-patch cosine similarity vs global reference fingerprint, confidence scales with patch count
- Real cameras: high consistent similarity; AI: low random similarity

Signal 30 — CFA Bayer (cfa_detector.py):
- Green-channel skip-0/skip-1 std ratio in both row and column directions
- FFT spectral peak supplement for periodic Bayer frequency pattern
- Real cameras: cfa_ratio < 0.90; AI images: ratio approx 1.0

Ensemble (advanced_ensemble_detector.py):
- Noiseprint weight 0.03, CFA weight 0.02 added to DIRE + fallback dicts
- DIRE branch weights redistributed, sum remains exactly 1.00
- detection_version v1.5 -> v1.6, methods_used 10 -> 12 entries

SSE (sse_analyzer.py):
- Both signals added to _run_extra, announces 30 signals

Tests (test_phase21_22.py):
- 32 tests: 13 Noiseprint, 13 CFA, 6 ensemble/SSE integration

Signal count assertions updated 28 -> 30 across 7 test files VERSION 7.4.0 -> 7.6.0, version tests updated