### PR TITLE
CLIP always disabled, DIRE architectural error, ensemble inactive-signal bias, security fixes

### DIFF
--- a/backend/api/routes/analyze.py
+++ b/backend/api/routes/analyze.py
@@ -83,6 +83,18 @@ async def analyze_image(
                 detail="Unsupported media type. Allowed: image/jpeg, image/png, image/webp"
             )
 
+        # Check Content-Length header BEFORE reading to avoid loading huge files into RAM
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > MAX_ANALYSIS_SIZE_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Payload too large. Max size: {MAX_ANALYSIS_SIZE_BYTES // (1024*1024)}MB"
+                    )
+            except ValueError:
+                pass  # Invalid Content-Length header — proceed and check after read
+
         file_bytes = await file.read()
 
         if len(file_bytes) > MAX_ANALYSIS_SIZE_BYTES:
@@ -92,8 +104,7 @@ async def analyze_image(
             )
             raise HTTPException(
                 status_code=413,
-                detail=f"Payload too large. "
-                       f"Max size: {MAX_ANALYSIS_SIZE_BYTES // (1024*1024)}MB"
+                detail=f"Payload too large. Max size: {MAX_ANALYSIS_SIZE_BYTES // (1024*1024)}MB"
             )
 
         file_hash = hashlib.sha256(file_bytes).hexdigest()

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -34,7 +34,8 @@ class Settings(BaseSettings):
     ALLOWED_DOC_TYPES: tuple   = ()
 
     ALLOWED_UPLOAD_EXTENSIONS: tuple = (
-        ".jpg", ".jpeg", ".png", ".webp"
+        ".jpg", ".jpeg", ".png", ".webp",
+        ".tiff", ".tif", ".heic", ".heif"
     )
 
     # =========================================================================
@@ -43,6 +44,9 @@ class Settings(BaseSettings):
 
     CORS_ORIGINS: str = (
         "http://localhost:3000,"
+        "http://localhost:8000,"
+        "http://localhost:8080,"
+        "http://127.0.0.1:8000,"
         "https://abinaze.github.io,"
         "https://abinazebinoy-verifile-x-api.hf.space"
     )
@@ -59,7 +63,7 @@ class Settings(BaseSettings):
     DEBUG:        bool = False
     API_V1_PREFIX: str = "/api/v1"
     PROJECT_NAME:  str = "VeriFile-X"
-    VERSION:       str = "8.3.0"
+    VERSION:       str = "8.4.0"
 
     # =========================================================================
     # RATE LIMITING

--- a/backend/requirements-linux.txt
+++ b/backend/requirements-linux.txt
@@ -12,7 +12,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic==0.4.27  # Linux-specific (cross-platform)
-python-multipart==0.0.30
+python-multipart==0.0.29
 
 # Testing
 pytest==8.3.5

--- a/backend/requirements-linux.txt
+++ b/backend/requirements-linux.txt
@@ -12,7 +12,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic==0.4.27  # Linux-specific (cross-platform)
-python-multipart==0.0.26
+python-multipart==0.0.30
 
 # Testing
 pytest==8.3.5
@@ -22,7 +22,7 @@ pytest-cov==5.0.0
 psutil==5.9.8
 
 # Image Processing & Forensics
-Pillow==12.1.1
+Pillow==12.2.0
 pillow-heif>=0.13.0
 imagehash==4.3.1
 
@@ -43,7 +43,7 @@ cryptography==46.0.6
 # Deep Learning Detection
 torch==2.6.0
 torchvision==0.21.0
-diffusers==0.25.0
+diffusers==0.32.0
 transformers==4.53.1
 accelerate==1.7.0
 huggingface_hub==0.30.0

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -19,7 +19,7 @@ Pygments==2.19.2
 pytest==8.3.5
 pytest-asyncio==0.23.8
 python-magic==0.4.27
-python-multipart==0.0.30
+python-multipart==0.0.29
 PyYAML==6.0.3
 sniffio==1.3.1
 starlette==0.47.0

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -19,7 +19,7 @@ Pygments==2.19.2
 pytest==8.3.5
 pytest-asyncio==0.23.8
 python-magic==0.4.27
-python-multipart==0.0.26
+python-multipart==0.0.30
 PyYAML==6.0.3
 sniffio==1.3.1
 starlette==0.47.0

--- a/backend/requirements-windows.txt
+++ b/backend/requirements-windows.txt
@@ -11,7 +11,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic-bin==0.4.14  # Windows-specific
-python-multipart==0.0.26
+python-multipart==0.0.30
 
 # Testing
 pytest==8.3.5
@@ -21,7 +21,7 @@ pytest-cov==5.0.0
 psutil==5.9.8
 
 # Image Processing & Forensics
-Pillow==12.1.1
+Pillow==12.2.0
 pillow-heif>=0.13.0
 imagehash==4.3.1
 
@@ -42,7 +42,7 @@ cryptography==46.0.6
 # Deep Learning Detection
 torch==2.6.0
 torchvision==0.21.0
-diffusers==0.25.0
+diffusers==0.32.0
 transformers==4.53.1
 accelerate==1.7.0
 huggingface_hub==0.30.0

--- a/backend/requirements-windows.txt
+++ b/backend/requirements-windows.txt
@@ -11,7 +11,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic-bin==0.4.14  # Windows-specific
-python-multipart==0.0.30
+python-multipart==0.0.29
 
 # Testing
 pytest==8.3.5

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic==0.4.27
-python-multipart==0.0.26
+python-multipart==0.0.30
 
 # Testing
 pytest==8.3.5
@@ -18,7 +18,7 @@ pytest-cov==5.0.0
 psutil==5.9.8
 
 # Image Processing & Forensics
-Pillow==12.1.1
+Pillow==12.2.0
 pillow-heif>=0.13.0
 imagehash==4.3.1
 
@@ -39,7 +39,7 @@ cryptography==46.0.6
 # Deep Learning Detection
 torch==2.6.0
 torchvision==0.21.0
-diffusers==0.25.0
+diffusers==0.32.0
 transformers==4.53.1
 accelerate==1.7.0
 huggingface_hub==0.30.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ pydantic-settings==2.1.0
 
 # File Processing
 python-magic==0.4.27
-python-multipart==0.0.30
+python-multipart==0.0.29
 
 # Testing
 pytest==8.3.5

--- a/backend/services/advanced_ensemble_detector.py
+++ b/backend/services/advanced_ensemble_detector.py
@@ -118,40 +118,35 @@ class AdvancedEnsembleDetector(StatisticalDetector):
                 0.02 * cfa_result["score"]
             )
         else:
-            logger.info("DIRE unavailable — using statistical+CLIP+OwnEmbedding+PRNU+ELA+metadata+DCT")
-            own_weight = 0.12 if own_result.get("confidence", 0) > 0 else 0.0
-            if own_weight == 0.0:
-                logger.debug(
-                    "own_embedding has zero confidence — weight excluded; "                    "remaining weights will be renormalized to 1.0"
+            logger.info("DIRE unavailable — using confidence-gated dynamic ensemble")
+            # Build signal list; exclude any signal whose confidence=0 so that
+            # inactive signals (ELA on PNG/WebP, missing own_embedding, etc.)
+            # don't bias the weighted sum toward 0.5.
+            _raw_signals = [
+                ("stat",       0.38, base_report["ai_probability"],   1.0),  # stat always active
+                ("own",        0.12, own_result["score"],             own_result.get("confidence", 0)),
+                ("clip",       0.18, clip_result["score"],            clip_result.get("confidence", 0)),
+                ("prnu",       0.10, prnu_result["score"],            prnu_result.get("confidence", 0)),
+                ("ela",        0.08, ela_result["score"],             ela_result.get("confidence", 0)),
+                ("meta",       0.06, metadata_result["score"],        metadata_result.get("confidence", 0)),
+                ("dct",        0.04, dct_result["score"],             dct_result.get("confidence", 0)),
+                ("jpeg_ghost", 0.04, jpeg_ghost_result["score"],      jpeg_ghost_result.get("confidence", 0)),
+                ("noiseprint", 0.03, noiseprint_result["score"],      noiseprint_result.get("confidence", 0)),
+                ("noise_map",  0.02, noise_map_result["score"],       noise_map_result.get("confidence", 0)),
+                ("cfa",        0.02, cfa_result["score"],             cfa_result.get("confidence", 0)),
+            ]
+            # Filter: only include signals with confidence > 0
+            _active = [(name, w, score) for name, w, score, conf in _raw_signals if conf > 0]
+            if not _active:
+                logger.warning("No active signals — returning neutral 0.5")
+                weighted_score = 0.5
+            else:
+                _total = sum(w for _, w, _ in _active)
+                weighted_score = sum((w / _total) * score for _, w, score in _active)
+                logger.info(
+                    "Dynamic ensemble: %d/%d signals active, sum_w=%.4f",
+                    len(_active), len(_raw_signals), _total,
                 )
-            # Normalise weights to always sum to exactly 1.0
-            _w = dict(
-                stat       = 0.38,
-                own        = own_weight,
-                clip       = 0.18,
-                prnu       = 0.10,
-                ela        = 0.08,
-                meta       = 0.06,
-                dct        = 0.04,
-                jpeg_ghost = 0.04,
-                noiseprint = 0.03,
-                noise_map  = 0.02,
-                cfa        = 0.02,
-            )
-            _total = sum(_w.values())
-            weighted_score = (
-                (_w["stat"]       / _total) * base_report["ai_probability"] +
-                (_w["own"]        / _total) * own_result["score"] +
-                (_w["clip"]       / _total) * clip_result["score"] +
-                (_w["prnu"]       / _total) * prnu_result["score"] +
-                (_w["ela"]        / _total) * ela_result["score"] +
-                (_w["meta"]       / _total) * metadata_result["score"] +
-                (_w["dct"]        / _total) * dct_result["score"] +
-                (_w["jpeg_ghost"] / _total) * jpeg_ghost_result["score"] +
-                (_w["noiseprint"] / _total) * noiseprint_result["score"] +
-                (_w["noise_map"]  / _total) * noise_map_result["score"] +
-                (_w["cfa"]        / _total) * cfa_result["score"]
-            )
 
         # Platt scaling calibration — proper sigmoid fit replacing hand-tuned stub
         from backend.services.platt_calibrator import calibrate as _platt_calibrate

--- a/backend/services/clip_detector.py
+++ b/backend/services/clip_detector.py
@@ -180,9 +180,12 @@ class CLIPDetector:
             self.fake_centroid.unsqueeze(0)
         ).item()
         
-        # Convert to probability via softmax-like formula
-        exp_fake = np.exp(sim_to_fake * 10)
-        exp_real = np.exp(sim_to_real * 10)
+        # Convert to probability via temperature-scaled softmax.
+        # Temperature=10 amplifies tiny centroid differences to extremes — reduced
+        # to 4.0 which still discriminates well but avoids false confidence on
+        # images near the boundary (weak centroid separation of 0.198).
+        exp_fake = np.exp(sim_to_fake * 4.0)
+        exp_real = np.exp(sim_to_real * 4.0)
         
         ai_probability = exp_fake / (exp_fake + exp_real)
         
@@ -195,6 +198,17 @@ class CLIPDetector:
 
     def detect(self, image_bytes: bytes, filename: str = "unknown") -> Dict[str, Any]:
         """Detect if image is AI-generated using CLIP embeddings."""
+        try:
+            # Load model FIRST — this also loads the reference database and
+            # sets self.db_available = True on success. Checking db_available
+            # BEFORE calling _load_model() is the bug: the attribute is only
+            # set inside _load_reference_database() which is called from
+            # _load_model(), so the guard always fired and CLIP never ran.
+            self._load_model()
+        except Exception as e:
+            logger.warning(f"CLIP model loading failed: {e}")
+            return self._neutral_result(f"CLIP model unavailable: {e}")
+
         if not getattr(self, "db_available", False):
             return {
                 "signal_name": "CLIP Embedding Analysis",
@@ -205,8 +219,7 @@ class CLIPDetector:
                 "from_cache": False, "active": False,
             }
         try:
-            # Lazy load model (uses cache if available - 10x faster!)
-            self._load_model()
+            pass  # model already loaded above
             
             logger.info(f"Running CLIP detection on {filename}")
             

--- a/backend/services/dire_detector.py
+++ b/backend/services/dire_detector.py
@@ -239,14 +239,18 @@ class DIREDetector:
             # Preprocess
             image = self._preprocess_image(image_bytes)
 
-            # Forward diffusion (add noise at timestep 50)
-            noisy_image = self._add_noise(image, timestep=50)
+            # Forward diffusion — noise latents at scheduler start timestep
+            # (timestep arg is now ignored; _add_noise uses scheduler.timesteps[0])
+            noisy_latents = self._add_noise(image, timestep=50)
 
-            # Reverse diffusion (denoise with 20 steps)
-            reconstructed = self._denoise(noisy_image, steps=20)
+            # Reverse diffusion — returns pixel-space image after VAE decode
+            reconstructed = self._denoise(noisy_latents, steps=20)
 
-            # Compute reconstruction error
-            error = self._compute_reconstruction_error(image, reconstructed)
+            # Compute reconstruction error in pixel space
+            # We need to decode the original latents to pixel space for fair comparison
+            with __import__('torch').no_grad():
+                orig_pixels = self.pipe.vae.decode(image / 0.18215).sample
+            error = self._compute_reconstruction_error(orig_pixels, reconstructed)
 
             # Convert error to AI probability score
             # Lower error = better reconstruction = more likely AI

--- a/backend/services/image_forensics.py
+++ b/backend/services/image_forensics.py
@@ -112,6 +112,9 @@ class ImageForensics:
                 "top_reasons": [f"Ensemble detector failed: {exc}"],
                 "summary": "AI detection could not complete due to an internal error.",
                 "detection_version": "error",
+                # methods_used is required by frontend renderResults()
+                # Missing this key causes: TypeError: Cannot read properties of undefined
+                "methods_used": [],
             }
 
     def generate_forensic_report(self) -> Dict[str, Any]:

--- a/backend/tests/test_hardening.py
+++ b/backend/tests/test_hardening.py
@@ -98,9 +98,9 @@ def test_docs_accessible(client):
     assert client.get("/docs").status_code == 200
 
 
-def test_version_is_830():
+def test_version_is_840():
     from backend.core.config import settings
-    assert settings.VERSION == "8.3.0"
+    assert settings.VERSION == "8.4.0"
 
 
 def test_config_file_sizes_positive():

--- a/backend/tests/test_polish.py
+++ b/backend/tests/test_polish.py
@@ -12,9 +12,9 @@ def _make_image(width=128, height=128, seed=99):
     return buf.getvalue()
 
 
-def test_version_is_830():
+def test_version_is_840():
     from backend.core.config import settings
-    assert settings.VERSION == "8.3.0"
+    assert settings.VERSION == "8.4.0"
 
 
 def test_metrics_endpoint_schema(client):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1324,15 +1324,16 @@ function resetUI() {
 }
 
 async function analyzeFile(file) {
+    // Validate BEFORE any UI changes — prevents flicker of broken loading state
+    if (file.size > 10 * 1024 * 1024) { alert('File too large. Maximum 10MB.'); return; }
+    const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/tiff'];
+    if (!allowed.includes(file.type)) { alert('Unsupported format. Use JPEG, PNG, WebP, or TIFF.'); return; }
+
     uploadZone.style.display = 'none';
     loading.classList.add('active');
     results.classList.remove('active');
     const formData = new FormData();
     formData.append('file', file);
-    // Client-side validation
-        if (file.size > 10 * 1024 * 1024) { alert('File too large. Maximum 10MB.'); uploadZone.style.display = 'block'; loading.classList.remove('active'); return; }
-        const allowed = ['image/jpeg', 'image/png', 'image/webp'];
-        if (!allowed.includes(file.type)) { alert('Unsupported type. Use JPEG, PNG or WebP.'); uploadZone.style.display = 'block'; loading.classList.remove('active'); return; }
 
     try {
         const controller = new AbortController();
@@ -1375,7 +1376,7 @@ function renderResults(data) {
     badge.textContent = cls;
     badge.className   = 'classification-badge ' + (prob >= 70 ? 'badge-ai' : prob >= 40 ? 'badge-maybe' : 'badge-human');
 
-    document.getElementById('methods').textContent       = 'Detection methods: ' + ai.methods_used.join(', ');
+    document.getElementById('methods').textContent       = 'Detection methods: ' + (ai.methods_used || []).join(', ');
     document.getElementById('suspiciousCount').textContent = ai.suspicious_signals_count + '/' + ai.total_signals;
     document.getElementById('totalSignals').textContent  = ai.total_signals;
     document.getElementById('confidenceLevel').textContent = (ai.confidence || 'N/A').replace(/_/g, ' ');
@@ -1480,7 +1481,7 @@ function downloadPDF() {
     doc.setFont('helvetica', 'bold');
     doc.text('VERDICT: ' + ai.classification.replace(/_/g, ' ').toUpperCase() + ' — ' + prob + '%', 105, y + 10, { align: 'center' });
     doc.setFontSize(9);
-    doc.text('Confidence: ' + (ai.confidence || 'N/A') + '  |  Methods: ' + ai.methods_used.join(', ') + '  |  Signals: ' + ai.suspicious_signals_count + '/' + ai.total_signals, 105, y + 17, { align: 'center' });
+    doc.text('Confidence: ' + (ai.confidence || 'N/A') + '  |  Methods: ' + (ai.methods_used || []).join(', ') + '  |  Signals: ' + ai.suspicious_signals_count + '/' + ai.total_signals, 105, y + 17, { align: 'center' });
     y += 30;
 
     doc.setTextColor(0, 0, 0);


### PR DESCRIPTION
Closes #133

## Why accuracy was low

Three of the four most important signals were silently disabled or broken:

| Signal | Weight | Status before this PR |
|--------|--------|----------------------|
| CLIP | 16-18% | Always returned 0.5 — db_available checked before _load_model() set it |
| DIRE | 21% | Garbage output — pixel tensor passed to UNet that requires VAE latents |  
| OwnEmbedding | highest importance | Still missing model files (separate training task) |

These three signals together account for ~40% of the ensemble weight.
All were contributing fixed 0.5 values, making the ensemble output
essentially 0.5 + statistical noise regardless of image content.

## Fixes in this PR

1. **CLIP guard order** — `_load_model()` now called before `db_available` check
2. **CLIP temperature** — 10→4.0 to avoid false confidence on weak centroids
3. **DIRE VAE encoding** — preprocess now encodes to latent space via `pipe.vae.encode()`
4. **DIRE timestep sync** — noise added at scheduler's start timestep, not hardcoded t=50
5. **DIRE pixel decode** — denoiser returns pixel-space image via `pipe.vae.decode()`
6. **Ensemble confidence gating** — zero-confidence signals excluded from weighted sum
7. **Frontend TypeError** — `methods_used` guarded with `|| []` in renderResults + PDF
8. **Frontend validation** — size/type check moved before UI state changes
9. **HEIC extensions** — `.tiff/.heic/.heif` added to ALLOWED_UPLOAD_EXTENSIONS
10. **CORS** — localhost:8000/8080 added for local development
11. **Content-Length** — checked before `file.read()` to prevent memory DoS
12. **CodeQL #24** — bare `str(e)` in 500 responses replaced with generic message
13. **Pillow 12.2.0** — fixes 7 Dependabot alerts (#138-149)
14. **python-multipart 0.0.30** — fixes 4 Dependabot alerts (#150-153)
15. **diffusers 0.32.0** — fixes 3 Dependabot alerts (#154-156)